### PR TITLE
モーダルリサイズ時のエラー対応

### DIFF
--- a/src/components/PhotoModal.tsx
+++ b/src/components/PhotoModal.tsx
@@ -13,7 +13,7 @@ type Props = {
   closeModal: () => void
 }
 
-Modal.setAppElement('body')
+Modal.setAppElement('main')
 
 export const PhotoModal = (props: Props) => {
   const { data, isOpen, closeModal, initialCount } = props


### PR DESCRIPTION
Blocked aria-hidden on a <body> element because it would hide the entire accessibility tree from assistive technology users. For more details, see the aria-hidden section of the WAI-ARIA specification